### PR TITLE
modify AdminSignIn & sign-in & sign-up .vue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1710,6 +1710,16 @@
           "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
           "dev": true
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "cacache": {
           "version": "13.0.1",
           "resolved": "https://registry.npmjs.org/cacache/-/cacache-13.0.1.tgz",
@@ -1736,6 +1746,53 @@
             "unique-filename": "^1.1.1"
           }
         },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true,
+          "optional": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true,
+          "optional": true
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
+          }
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -1750,6 +1807,16 @@
           "requires": {
             "figgy-pudding": "^3.5.1",
             "minipass": "^3.1.1"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         },
         "terser-webpack-plugin": {
@@ -1767,6 +1834,18 @@
             "source-map": "^0.6.1",
             "terser": "^4.6.12",
             "webpack-sources": "^1.4.3"
+          }
+        },
+        "vue-loader-v16": {
+          "version": "npm:vue-loader@16.1.2",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
+          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+          "dev": true,
+          "optional": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "hash-sum": "^2.0.0",
+            "loader-utils": "^2.0.0"
           }
         }
       }
@@ -10982,87 +11061,6 @@
           "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
           "integrity": "sha1-M7QHd3VMZDJXPBIMw4CLvRDUfwQ=",
           "dev": true
-        }
-      }
-    },
-    "vue-loader-v16": {
-      "version": "npm:vue-loader@16.1.2",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-      "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "hash-sum": "^2.0.0",
-        "loader-utils": "^2.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true,
-          "optional": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true
-        },
-        "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^3.0.0",
-            "json5": "^2.1.2"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
         }
       }
     },

--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -145,7 +145,7 @@ export default {
   computed: {
     ...mapState(["currentUser", "isAuthenticated"]),
     isDescriptionOverSize() {
-      return this.description.length > 140 ? true : false
+      return this.description.length > 140 ? true : false;
     },
   },
 

--- a/src/components/NewTweet.vue
+++ b/src/components/NewTweet.vue
@@ -60,7 +60,7 @@ export default {
   computed: {
     ...mapState(["currentUser", "isAuthenticated"]),
     isDescriptionOverSize() {
-      return this.description.length > 140 ? true : false
+      return this.description.length > 140 ? true : false;
     },
   },
   created() {

--- a/src/views/AdminSignIn.vue
+++ b/src/views/AdminSignIn.vue
@@ -19,7 +19,7 @@
             id="InputAcount"
             aria-describedby="emailHelp"
             required
-            autofocus
+            v-focus
           />
         </div>
       </div>
@@ -56,9 +56,9 @@
 </template>
 
 <script>
-import Logo from "./../components/Logo"
-import authorizationAPI from './../apis/authorization'
-import { Toast } from './../utils/helpers'
+import Logo from "./../components/Logo";
+import authorizationAPI from "./../apis/authorization";
+import { Toast } from "./../utils/helpers";
 
 export default {
   components: {
@@ -66,55 +66,61 @@ export default {
   },
   data() {
     return {
-      email: '',
-      password: '',
-      isProcessing: false
-    }
+      email: "",
+      password: "",
+      isProcessing: false,
+    };
   },
   methods: {
     async handleSubmit() {
       try {
         if (!this.email || !this.password) {
           Toast.fire({
-            icon: 'warning',
-            title: '請填入 email 和 password'
-          })
-          return
+            icon: "warning",
+            title: "請填入 email 和 password",
+          });
+          return;
         }
 
-        this.isProcessing = true
+        this.isProcessing = true;
 
         const response = await authorizationAPI.AdminSignIn({
           email: this.email,
-          password: this.password
-        })
+          password: this.password,
+        });
 
-        const { data } = response
+        const { data } = response;
 
-        console.log(data.user)
+        console.log(data.user);
 
-        if (data.status !== 'success') {
-          throw new Error(data.message)
+        if (data.status !== "success") {
+          throw new Error(data.message);
         }
 
-        localStorage.setItem('token', data.token)
-        this.$store.commit('setCurrentUser', data.user)
-        this.isProcessing = false
+        localStorage.setItem("token", data.token);
+        this.$store.commit("setCurrentUser", data.user);
+        this.isProcessing = false;
 
-        this.$router.push('/admin/tweets')
-
+        this.$router.push("/admin/tweets");
       } catch (error) {
-        console.log(error)
-        this.password = ''
-        this.isProcessing = false
+        console.log(error);
+        this.password = "";
+        this.isProcessing = false;
 
         Toast.fire({
-          icon: 'warning',
-          title: '請確認您輸入了正確的帳號密碼'
-        })
+          icon: "warning",
+          title: "請確認您輸入了正確的帳號密碼",
+        });
       }
-    }
-  }
+    },
+  },
+  directives: {
+    focus: {
+      inserted: function (el) {
+        el.focus();
+      },
+    },
+  },
 };
 </script>
 

--- a/src/views/SignIn.vue
+++ b/src/views/SignIn.vue
@@ -13,7 +13,7 @@
           type="email"
           class="form-control"
           required
-          autofocus
+          v-focus
           aria-describedby="emailHelp"
         />
         <div id="emailHelp" class="form-text"></div>
@@ -55,8 +55,8 @@
 
 <script>
 import Logo from "./../components/Logo";
-import authorizationAPI from './../apis/authorization'
-import { Toast } from './../utils/helpers'
+import authorizationAPI from "./../apis/authorization";
+import { Toast } from "./../utils/helpers";
 
 export default {
   components: {
@@ -64,54 +64,68 @@ export default {
   },
   data() {
     return {
-      email: '',
-      password: '',
-      isProcessing: false
-    }
+      email: "",
+      password: "",
+      isProcessing: false,
+    };
   },
   methods: {
     async handleSubmit() {
       try {
         if (!this.email || !this.password) {
           Toast.fire({
-            icon: 'warning',
-            title: '請填入 email 和 password'
-          })
-          return
+            icon: "warning",
+            title: "請填入 email 和 password",
+          });
+          return;
         }
 
-        this.isProcessing = true
+        if (this.email.search("@") === -1) {
+          Toast.fire({
+            icon: "warning",
+            title: "請填入註冊時email",
+          });
+          return;
+        }
+
+        this.isProcessing = true;
 
         const response = await authorizationAPI.SignIn({
           email: this.email,
-          password: this.password
-        })
+          password: this.password,
+        });
 
-        const { data } = response
+        const { data } = response;
 
-        if (data.status !== 'success') {
-          throw new Error(data.message)
+        if (data.status !== "success") {
+          throw new Error(data.message);
         }
 
-        localStorage.setItem('token', data.token)
-        console.log(data.user)
-        this.$store.commit('setCurrentUser', data.user)
-        this.isProcessing = false
+        localStorage.setItem("token", data.token);
+        console.log(data.user);
+        this.$store.commit("setCurrentUser", data.user);
+        this.isProcessing = false;
 
-        this.$router.push('/home')
-
+        this.$router.push("/home");
       } catch (error) {
-        console.log(error)
-        this.password = ''
-        this.isProcessing = false
+        console.log(error);
+        this.password = "";
+        this.isProcessing = false;
 
         Toast.fire({
-          icon: 'warning',
-          title: '請確認您輸入了正確的帳號密碼'
-        })
+          icon: "warning",
+          title: "請確認您輸入了正確的帳號密碼",
+        });
       }
-    }
-  }
+    },
+  },
+  directives: {
+    focus: {
+      inserted: function (el) {
+        el.focus();
+      },
+    },
+  },
 };
 </script>
 
@@ -207,7 +221,7 @@ input {
   font-size: 18px;
   line-height: 26px;
   text-align: right;
-  text-decoration-line: underline;
+  text-decoration-line: none;
   color: #0099ff;
 }
 

--- a/src/views/SignUp.vue
+++ b/src/views/SignUp.vue
@@ -13,6 +13,7 @@
           name="account"
           type="text"
           class="form-control"
+          v-focus
           required
         />
       </div>
@@ -92,8 +93,8 @@
 
 <script>
 import Logo from "./../components/Logo";
-import authorizationAPI from './../apis/authorization'
-import { Toast } from './../utils/helpers'
+import authorizationAPI from "./../apis/authorization";
+import { Toast } from "./../utils/helpers";
 
 export default {
   components: {
@@ -106,79 +107,84 @@ export default {
       email: "",
       password: "",
       checkPassword: "",
-      isProcessing: false
+      isProcessing: false,
     };
   },
   methods: {
     async handleSubmit() {
       if (!this.name) {
         Toast.fire({
-          icon: 'warning',
-          title: '請填寫名稱'
-        })
-        return
+          icon: "warning",
+          title: "請填寫名稱",
+        });
+        return;
       } else if (!this.account) {
         Toast.fire({
-          icon: 'warning',
-          title: '請填寫帳號'
-        })
-        return
+          icon: "warning",
+          title: "請填寫帳號",
+        });
+        return;
       } else if (!this.email) {
         Toast.fire({
-          icon: 'warning',
-          title: '請填寫Email'
-        })
-        return
+          icon: "warning",
+          title: "請填寫Email",
+        });
+        return;
       } else if (!this.password) {
         Toast.fire({
-          icon: 'warning',
-          title: '請填寫密碼'
-        })
-        return
+          icon: "warning",
+          title: "請填寫密碼",
+        });
+        return;
       } else if (!this.checkPassword) {
         Toast.fire({
-          icon: 'warning',
-          title: '請填寫密碼確認'
-        })
-        return
+          icon: "warning",
+          title: "請填寫密碼確認",
+        });
+        return;
       } else if (this.checkPassword !== this.password) {
         Toast.fire({
-          icon: 'warning',
-          title: '密碼與密碼確認不符'
-        })
-        return
+          icon: "warning",
+          title: "密碼與密碼確認不符",
+        });
+        return;
       }
 
       try {
-        this.isProcessing = true
+        this.isProcessing = true;
         const response = await authorizationAPI.SignUp({
           account: this.account,
           name: this.name,
           email: this.email,
           password: this.password,
-          checkPassword: this.checkPassword
-        })
+          checkPassword: this.checkPassword,
+        });
 
         if (response.status === "error") {
-          throw new Error(response.message)
+          throw new Error(response.message);
         }
 
         Toast.fire({
-          icon: 'success',
-          title: `建立成功！ 請登入`
-        })
-        this.isProcessing = false
-        this.$router.push({ name: 'sign-in' })
-
+          icon: "success",
+          title: `建立成功！ 請登入`,
+        });
+        this.isProcessing = false;
+        this.$router.push({ name: "sign-in" });
       } catch (error) {
-        console.log('err', error)
+        console.log("err", error);
         Toast.fire({
-          icon: 'error',
-          title: `無法建立帳號，${error}`
-        })
-        this.isProcessing = false
+          icon: "error",
+          title: `無法建立帳號，${error}`,
+        });
+        this.isProcessing = false;
       }
-
+    },
+  },
+  directives: {
+    focus: {
+      inserted: function (el) {
+        el.focus();
+      },
     },
   },
 };

--- a/src/views/UserSetting.vue
+++ b/src/views/UserSetting.vue
@@ -143,24 +143,29 @@ export default {
           name: this.name,
           email: this.email,
           password: this.password,
-          checkPassword: this.checkPassword
-        }
+          checkPassword: this.checkPassword,
+        };
 
-        const response = await authorizationAPI.EditUserSetting(userEditContent)
+        const response = await authorizationAPI.EditUserSetting(
+          userEditContent
+        );
 
         if (response.status === "error") {
           throw new Error(response.message);
         }
 
-        userEditContent = { ...userEditContent, password: "", checkPassword: "" }
+        userEditContent = {
+          ...userEditContent,
+          password: "",
+          checkPassword: "",
+        };
 
         Toast.fire({
-          icon: 'success',
-          title: `修改成功！`
-        })
-        this.$store.commit('setCurrentUser', userEditContent)
-        this.$router.push({ name: 'home' })
-
+          icon: "success",
+          title: `修改成功！`,
+        });
+        this.$store.commit("setCurrentUser", userEditContent);
+        this.$router.push({ name: "home" });
       } catch (error) {
         console.log("err", error);
         Toast.fire({


### PR DESCRIPTION
描述這組程式碼變動的目的:
1.在AdminSignIn & sign-in & sign-up .vue中加入了,自定義v-focus函數，刪除autofocus，可以讓進頁面直接請使用者輸入
2.sign-in頁面，因為標題為帳號，但輸入帳號會噴帳密不對，加入檢查if函式，讓使用者知道必須要輸入信箱
必要檢查 Checklist:
✅ 在 UI 上的改動可令人接受
✅ 程式碼看起來不錯，複雜度適中
✅ 沒有不必要的程式碼
✅ 命名適當
✅ Coding style 一致

用雞蛋裡挑骨頭的精神找優化空間:
1.其實你們也有做到好多我們沒有想到的功能，學習很多！但真的要講，以我們的頁面是讓首頁部分中間推文部分可以持續在上面，下面Tweets.components如果有固定高度，可以捲動，捲軸其實可以隱藏，以上也是我們這組UI架構分享給你們